### PR TITLE
🐛 Use automerge.Text in speaker id if only 1 para

### DIFF
--- a/worker/transcribee_worker/identify_speakers.py
+++ b/worker/transcribee_worker/identify_speakers.py
@@ -22,7 +22,7 @@ async def identify_speakers(
         if len(doc.children) == 0:
             return
         elif len(doc.children) == 1:
-            doc.children[0].speaker = "1"
+            doc.children[0].speaker = automerge.Text("1")
             return
 
         def time_to_sample(time: float | None):


### PR DESCRIPTION
This fixes the frontend showing `Unnamed Speaker [object Object]` in documents with only one paragraph
