### PR TITLE
🐛 Fix speaker buttons showing over speakerdropdown

### DIFF
--- a/frontend/src/components/dropdown.tsx
+++ b/frontend/src/components/dropdown.tsx
@@ -96,6 +96,9 @@ export function Dropdown({
           'hover:bg-gray-200 dark:hover:bg-neutral-700',
           show.now && 'bg-gray-200 dark:bg-neutral-700 !opacity-100',
           'px-2 py-1',
+          'relative',
+          'hover:z-10',
+          show.prolonged && 'z-50',
           buttonClassName,
         )}
         aria-expanded={show.now}

--- a/frontend/src/editor/transcription_editor.tsx
+++ b/frontend/src/editor/transcription_editor.tsx
@@ -87,7 +87,6 @@ function Paragraph({ element, children, attributes }: RenderElementProps): JSX.E
           'mx-2 -mt-0.5 md:mt-0 md:-ml-2',
           'row-start-1 col-start-2', // render on top of speaker name
           'md:max-h-7', // prevent extensive whitespace on paragraph when dropdown is only shown on hover
-          'z-10',
         )}
       >
         {!readOnly && (


### PR DESCRIPTION
To be honest, I don't understand *why* this fixes it, but it does?

Fixes #316 
