### PR TITLE
⚡️ Only render children if in view 

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -65,6 +65,7 @@
     "react-helmet": "^6.1.0",
     "react-hook-form": "^7.43.5",
     "react-icons": "^4.8.0",
+    "react-intersection-observer": "^9.5.2",
     "react-json-tree": "^0.18.0",
     "react-popper": "^2.3.0",
     "reconnecting-websocket": "^4.4.0",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -43,6 +43,9 @@ dependencies:
   react-icons:
     specifier: ^4.8.0
     version: 4.8.0(react@18.2.0)
+  react-intersection-observer:
+    specifier: ^9.5.2
+    version: 9.5.2(react@18.2.0)
   react-json-tree:
     specifier: ^0.18.0
     version: 0.18.0(@types/react@18.0.28)(react@18.2.0)
@@ -4232,6 +4235,14 @@ packages:
     resolution: {integrity: sha512-N6+kOLcihDiAnj5Czu637waJqSnwlMNROzVZMhfX68V/9bu9qHaMIJC4UdozWoOk57gahFCNHwVvWzm0MTzRjg==}
     peerDependencies:
       react: '*'
+    dependencies:
+      react: 18.2.0
+    dev: false
+
+  /react-intersection-observer@9.5.2(react@18.2.0):
+    resolution: {integrity: sha512-EmoV66/yvksJcGa1rdW0nDNc4I1RifDWkT50gXSFnPLYQ4xUptuDD4V7k+Rj1OgVAlww628KLGcxPXFlOkkU/Q==}
+    peerDependencies:
+      react: ^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0
     dependencies:
       react: 18.2.0
     dev: false


### PR DESCRIPTION
Rendering just the text (so that searching and scrolling still kindof work) leads to better initial loading performance
