### PR TITLE
Add debian+nix dev container

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,4 @@
+FROM ghcr.io/xtruder/nix-devcontainer:v1
+
+# cache /nix
+VOLUME /nix

--- a/.devcontainer/compose.yml
+++ b/.devcontainer/compose.yml
@@ -1,0 +1,16 @@
+version: '3'
+services:
+  dev:
+    build:
+      dockerfile: ./Dockerfile
+      args:
+        USER_UID: ${UID:-1000}
+        USER_GID: ${GID:-1000}
+    volumes:
+      - ..:/workspace:cached
+      - nix:/nix
+    security_opt:
+      - label:disable
+    network_mode: "bridge"
+volumes:
+  nix:

--- a/.devcontainer/compose.yml
+++ b/.devcontainer/compose.yml
@@ -6,6 +6,7 @@ services:
       args:
         USER_UID: ${UID:-1000}
         USER_GID: ${GID:-1000}
+      context: ./
     volumes:
       - ..:/workspace:cached
       - nix:/nix

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,24 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/debian
+{
+	"name": "Debian",
+	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+	"image": "mcr.microsoft.com/devcontainers/base:bullseye",
+	"features": {
+		"ghcr.io/devcontainers/features/nix:1": {
+			"version": "latest"
+		}
+	}
+
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	// "features": {},
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Configure tool-specific properties.
+	// "customizations": {},
+
+	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "root"
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,14 +1,11 @@
 // For format details, see https://aka.ms/devcontainer.json. For config options, see the
 // README at: https://github.com/devcontainers/templates/tree/main/src/debian
 {
-	"name": "Debian",
-	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
-	"image": "mcr.microsoft.com/devcontainers/base:bullseye",
-	"features": {
-		"ghcr.io/devcontainers/features/nix:1": {
-			"version": "latest"
-		}
-	}
+	"name": "Nix",
+
+	"dockerComposeFile": "compose.yml",
+	"service": "dev",
+	"workspaceFolder": "/workspace",
 
 	// Features to add to the dev container. More info: https://containers.dev/features.
 	// "features": {},
@@ -16,9 +13,36 @@
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// "forwardPorts": [],
 
+	"overrideCommand": false,
+	"userEnvProbe": "loginShell",
+	"updateRemoteUserUID": false,
+
+	"portsAttributes": {
+		"5173": {
+			"label": "Transcribee",
+			"onAutoForward": "notify"
+		}
+	},
+
+	"onCreateCommand": "nix-shell shell.nix --command ./packaging/install_dependencies.sh",
+
 	// Configure tool-specific properties.
-	// "customizations": {},
+	"customizations": {
+		"vscode": {
+			"extensions": [
+				"arrterian.nix-env-selector"
+			]
+		}
+	}
 
 	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
 	// "remoteUser": "root"
+
+	// This is purely informative: https://containers.dev/implementors/json_reference/#min-host-reqs
+	// "hostRequirements": {
+	// 	"cpus": 4,
+	// 	"memory": "8gb",
+	// 	"storage": "20gb",
+	// 	"gpu": true
+	// }
 }

--- a/doc/development_setup.md
+++ b/doc/development_setup.md
@@ -23,6 +23,17 @@ If you just want to try out `transcribee`, you need to go through the following 
    interact with the running transcribee instance. An admin user with the username "test" and the
    password "test" is created for you.
 
+## Minimal setup (Dev Containers)
+
+[Dev Containers](https://containers.dev/) allow you to use a container as a full-featured development
+environment. If your IDE (such as VS Code) supports it, it should offer you an option to build the
+dev container and reopen the project within the container. You need to have Docker or another compatible
+container runtime installed.
+
+The `transcribee` dev container is based on [nix-devcontainer](https://github.com/xtruder/nix-devcontainer/).
+On first run, the dev container will automatically build the nix environment and install dev dependencies,
+which may take a while. Subsequent runs or rebuilds will preserve the nix cache and should be much faster.
+
 ## Minimal setup (Docker)
 
 If you just want to try out `transcribee` and **not** install nix, you need to go through


### PR DESCRIPTION
This commit adds a dev container configuration file for a debian bullseye + nix container. Supporting IDEs, such as VS Code, should offer to open the cloned repository in the dev container, where users can then follow the [minimal setup](https://github.com/bugbakery/transcribee/blob/main/doc/development_setup.md#minimal-setup-nix) steps to quickly have a running dev instance without fiddling with their linux distro or nix locally.

It's a little bit more comfortable for VS Code users than the minimal docker setup.