### PR TITLE
Add /.pnpm-store to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .direnv
+/.pnpm-store


### PR DESCRIPTION
Following the instructions in the dev docs, `/.pnpm-store` gets a ton of files installed. Git dutifully and needlessly tries to scan for changes there, which is slow.