### PR TITLE
worker: factor out video codec to be easily configurable

### DIFF
--- a/worker/transcribee_worker/config.py
+++ b/worker/transcribee_worker/config.py
@@ -2,6 +2,7 @@ import os
 from pathlib import Path
 from typing import Dict, Optional
 
+from pydantic import Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -11,30 +12,33 @@ class Settings(BaseSettings):
 
     HUGGINGFACE_TOKEN: Optional[str] = None
 
-    REENCODE_PROFILES: Dict[str, Dict[str, str]] = {
-        "mp3": {
-            "format": "mp3",
-            "audio_bitrate": "128k",
-            "ac": "1",
-        },
-        "m4a": {
-            "format": "mp4",
-            "audio_bitrate": "128k",
-            "ac": "1",
-        },
-        "video:mp4": {
-            "format": "mp4",
-            "audio_bitrate": "128k",
-            "ac": "1",
-            "c:v": "libx264",
-            "crf": "26",
-            "preset": "faster",
-            # downscale to 480p and pad to multiple of 2 (needed for libx264)
-            "vf": "scale='min(854,iw)':'min(480,ih)'"
-            ":force_original_aspect_ratio=decrease,"
-            "pad='iw+mod(iw\\,2)':'ih+mod(ih\\,2)",
-        },
-    }
+    REENCODE_VIDEO_CODEC: str = "libx264"
+    REENCODE_PROFILES: Dict[str, Dict[str, str]] = Field(
+        default_factory=lambda data: {
+            "mp3": {
+                "format": "mp3",
+                "audio_bitrate": "128k",
+                "ac": "1",
+            },
+            "m4a": {
+                "format": "mp4",
+                "audio_bitrate": "128k",
+                "ac": "1",
+            },
+            "video:mp4": {
+                "format": "mp4",
+                "audio_bitrate": "128k",
+                "ac": "1",
+                "c:v": data["REENCODE_VIDEO_CODEC"],
+                "crf": "26",
+                "preset": "faster",
+                # downscale to 480p and pad to multiple of 2 (needed for libx264)
+                "vf": "scale='min(854,iw)':'min(480,ih)'"
+                ":force_original_aspect_ratio=decrease,"
+                "pad='iw+mod(iw\\,2)':'ih+mod(ih\\,2)",
+            },
+        }
+    )
 
     KEEPALIVE_INTERVAL: float = 0.5
 


### PR DESCRIPTION
Then we can switch (more easily) to `h264_videotoolbox` on the mac worker.