### PR TITLE
Add CI coverage for Docker setup

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,8 +1,10 @@
 name: Create and publish a Docker image
 
 on:
+  pull_request:
   push:
     branches: ["main"]
+  merge_group:
 
 env:
   REGISTRY: ghcr.io
@@ -17,21 +19,25 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
 
       - name: Log in to the Container registry
-        uses: docker/login-action@v2
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Validate Docker Compose configuration
+        run: docker compose -f compose.yml config
+
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
@@ -43,10 +49,10 @@ jobs:
             type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v6
         with:
           context: .
-          push: true
+          push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           file: packaging/Dockerfile


### PR DESCRIPTION
## Summary
- runs the Docker workflow for pull requests and merge queue events, not just pushes to `main`
- keeps GHCR login and image push limited to `main` pushes
- validates `compose.yml` before the Docker image build
- updates the Docker workflow actions so the new CI path runs on current action runtimes

Closes #461.

## Verification
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/docker.yml"); puts "docker.yml yaml ok"'`\n- `docker compose -f compose.yml config`\n- `go run github.com/rhysd/actionlint/cmd/actionlint@latest -color=false .github/workflows/docker.yml`\n- `git diff --check`