### PR TITLE
Improve speaker handling and player controls

### DIFF
--- a/frontend/src/components/form.tsx
+++ b/frontend/src/components/form.tsx
@@ -106,8 +106,8 @@ export const Select = primitiveWithClassname('select', [
   'dark:focus:ring-blue-400 dark:focus:border-blue-400',
 ]);
 
-export const Slider = forwardRef<HTMLInputElement>(
-  ({ ...props }: Omit<ComponentProps<'input'>, 'type'>, ref) => {
+export const Slider = forwardRef<HTMLInputElement, Omit<ComponentProps<'input'>, 'type'>>(
+  ({ ...props }, ref) => {
     const innerRef = useRef<HTMLInputElement>(null as unknown as HTMLInputElement);
     useImperativeHandle(ref, () => innerRef.current);
 

--- a/frontend/src/document.test.ts
+++ b/frontend/src/document.test.ts
@@ -3,6 +3,7 @@ import { migrateDocument } from './document';
 import { Document } from './editor/types';
 import { next as Automerge } from '@automerge/automerge';
 import * as fs from 'fs';
+import { getSpeakerIDs } from './utils/document';
 
 function testMigrate(baseName: string) {
   const doc = Automerge.load(fs.readFileSync(`testData/${baseName}.dat`, null));
@@ -19,4 +20,68 @@ test('migrateV1', () => {
 
 test('migrateV2', () => {
   testMigrate('docV2');
+});
+
+test('getSpeakerIDs keeps existing speaker color order stable', () => {
+  const doc: Document = {
+    children: [
+      {
+        type: 'paragraph',
+        speaker: 'speaker-b',
+        lang: 'en',
+        children: [{ text: 'hello' }],
+      },
+      {
+        type: 'paragraph',
+        speaker: 'speaker-a',
+        lang: 'en',
+        children: [{ text: 'world' }],
+      },
+      {
+        type: 'paragraph',
+        speaker: 'speaker-c',
+        lang: 'en',
+        children: [{ text: 'again' }],
+      },
+    ],
+    speaker_names: {
+      'speaker-a': 'Alice',
+      'speaker-b': 'Bob',
+      'speaker-c': 'Charlie',
+    },
+    version: 3,
+  };
+
+  expect(getSpeakerIDs(doc)).toStrictEqual(['speaker-a', 'speaker-b', 'speaker-c']);
+});
+
+test('getSpeakerIDs appends unnamed speakers after known ones', () => {
+  const doc: Document = {
+    children: [
+      {
+        type: 'paragraph',
+        speaker: 'speaker-a',
+        lang: 'en',
+        children: [{ text: 'hello' }],
+      },
+      {
+        type: 'paragraph',
+        speaker: 'speaker-z',
+        lang: 'en',
+        children: [{ text: 'world' }],
+      },
+      {
+        type: 'paragraph',
+        speaker: null,
+        lang: 'en',
+        children: [{ text: 'again' }],
+      },
+    ],
+    speaker_names: {
+      'speaker-a': 'Alice',
+    },
+    version: 3,
+  };
+
+  expect(getSpeakerIDs(doc)).toStrictEqual(['speaker-a', 'speaker-z']);
 });

--- a/frontend/src/editor/player.tsx
+++ b/frontend/src/editor/player.tsx
@@ -16,11 +16,14 @@ import { sortMediaFiles, useAudio } from '../utils/use_audio';
 import { minutesInMs } from '../utils/duration_in_ms';
 import { formattedTime } from './transcription_editor';
 import { IconType } from 'react-icons';
-import { BiVideo, BiVideoOff } from 'react-icons/bi';
+import { BiVideo, BiVideoOff, BiVolumeFull, BiVolumeLow, BiVolumeMute } from 'react-icons/bi';
+import { MdReplay } from 'react-icons/md';
+import { Slider } from '../components/form';
 
 const DOUBLE_TAP_THRESHOLD_MS = 250;
 const SKIP_BUTTON_SEC = 2;
 const SKIP_SHORTCUT_SEC = 3;
+const SLOW_REPLAY_RATE = 0.7;
 
 let lastTabPressTs = 0;
 
@@ -69,12 +72,14 @@ export function PlayerBar({
   );
 
   const [playbackRate, setPlaybackRate] = useLocalStorage('playbackRate', 1);
+  const [volume, setVolume] = useLocalStorage('playbackVolume', 1);
 
   const [showVideo, setShowVideo] = useState(true);
   const reallyShowVideo = showVideo && hasVideo;
 
   const audio = useAudio({
     playbackRate,
+    volume,
     sources: reallyShowVideo ? videoSources : audioSources,
     videoPreview: reallyShowVideo,
     documentId,
@@ -131,6 +136,14 @@ export function PlayerBar({
     }
   };
 
+  const replaySlow = useCallback(() => {
+    audio.seekRelative(-SKIP_SHORTCUT_SEC);
+    setPlaybackRate((currentRate) => Math.min(currentRate, SLOW_REPLAY_RATE));
+    if (!audio.playing) {
+      audio.play();
+    }
+  }, [audio, setPlaybackRate]);
+
   useEvent<KeyboardEvent>('keydown', (e) => {
     if (e.key == 'Tab') {
       // double tap to skip
@@ -145,6 +158,13 @@ export function PlayerBar({
       lastTabPressTs = e.timeStamp;
 
       togglePlaying();
+      e.stopPropagation();
+      e.preventDefault();
+      return;
+    }
+
+    if (e.altKey && e.key.toLowerCase() == 'r') {
+      replaySlow();
       e.stopPropagation();
       e.preventDefault();
     }
@@ -218,6 +238,18 @@ export function PlayerBar({
         </div>
 
         <PlaybackSpeedDropdown value={playbackRate} onChange={setPlaybackRate} />
+        <IconButton
+          icon={MdReplay}
+          label="replay slow (Alt+R)"
+          onClick={replaySlow}
+          className="ml-1 gap-1 px-2.5 rounded-full"
+          size={18}
+        >
+          <span className="hidden text-xs font-semibold sm:inline">
+            {SLOW_REPLAY_RATE.toFixed(1)}x
+          </span>
+        </IconButton>
+        <VolumeControl value={volume} onChange={setVolume} />
         {hasVideo && (
           <IconButton
             icon={reallyShowVideo ? BiVideoOff : BiVideo}
@@ -227,6 +259,44 @@ export function PlayerBar({
         )}
       </div>
     </>
+  );
+}
+
+function VolumeControl({
+  value,
+  onChange,
+}: {
+  value: number;
+  onChange: (nextValue: number) => void;
+}) {
+  const previousVolumeRef = useRef(value || 1);
+
+  useEffect(() => {
+    if (value > 0) {
+      previousVolumeRef.current = value;
+    }
+  }, [value]);
+
+  const VolumeIcon = value === 0 ? BiVolumeMute : value < 0.5 ? BiVolumeLow : BiVolumeFull;
+
+  return (
+    <div className="ml-2 flex w-20 items-center gap-1 sm:w-28 sm:gap-2">
+      <IconButton
+        icon={VolumeIcon}
+        label={value === 0 ? 'unmute' : 'mute'}
+        discreet
+        onClick={() => onChange(value === 0 ? previousVolumeRef.current : 0)}
+        className="p-1"
+      />
+      <Slider
+        min={0}
+        max={1}
+        step={0.05}
+        value={value}
+        aria-label="volume"
+        onChange={(e) => onChange(parseFloat(e.target.value))}
+      />
+    </div>
   );
 }
 

--- a/frontend/src/editor/speaker_dropdown.tsx
+++ b/frontend/src/editor/speaker_dropdown.tsx
@@ -94,6 +94,18 @@ function SpeakerNameModal({
 }
 
 function setSpeaker(editor: Editor, path: number[], speaker: string | null) {
+  if (speaker === null) {
+    const newDoc = Automerge.change(editor.doc, (draft: Document) => {
+      const endIdx = calculateParagraphIdxOfSpeakerEnd(editor, path[0]);
+
+      for (let i = path[0]; i <= endIdx; i++) {
+        draft.children[i].speaker = null;
+      }
+    });
+    editor.setDoc(newDoc);
+    return;
+  }
+
   const endPath = calculateParagraphIdxOfSpeakerEnd(editor, path[0]);
 
   Transforms.setNodes(

--- a/frontend/src/utils/document.ts
+++ b/frontend/src/utils/document.ts
@@ -75,10 +75,22 @@ export function useSpeakerNames(editor?: Editor): Record<string, string> {
   );
 }
 
+export function getSpeakerIDs(doc: Document) {
+  const speakerIDs = Object.keys(doc.speaker_names);
+
+  for (const paragraph of doc.children || []) {
+    if (paragraph.speaker !== null && !speakerIDs.includes(paragraph.speaker)) {
+      speakerIDs.push(paragraph.speaker);
+    }
+  }
+
+  return speakerIDs;
+}
+
 export function useSpeakerIDs(editor?: Editor) {
   return useDocumentSelector(
     useCallback((newDoc) => {
-      return [...new Set((newDoc.children || []).map((child) => child.speaker))].sort();
+      return getSpeakerIDs(newDoc);
     }, []),
     { eq: compareJSON, editor: editor },
   );

--- a/frontend/src/utils/use_audio.ts
+++ b/frontend/src/utils/use_audio.ts
@@ -5,12 +5,19 @@ import { padRect, rectContains } from './rect_utils';
 
 type UseAudioOptions = {
   playbackRate?: number;
+  volume?: number;
   sources: Array<{ src: string; type: string }>;
   videoPreview?: boolean;
   documentId: string;
 };
 
-export function useAudio({ sources, playbackRate, videoPreview, documentId }: UseAudioOptions) {
+export function useAudio({
+  sources,
+  playbackRate,
+  volume,
+  videoPreview,
+  documentId,
+}: UseAudioOptions) {
   const [playing, setPlayingState] = useState(false);
   const [duration, setDuration] = useState<number | undefined>();
   const [buffering, setBuffering] = useState(false);
@@ -203,6 +210,12 @@ export function useAudio({ sources, playbackRate, videoPreview, documentId }: Us
       actions(playerElement).setRate(playbackRate);
     }
   }, [playerElement, sources, playbackRate]);
+
+  useEffect(() => {
+    if (!playerElement || volume == undefined) return;
+
+    playerElement.volume = Math.max(0, Math.min(volume, 1));
+  }, [playerElement, sources, volume]);
 
   const setPlaytime = useCallback(
     (sec: number) => {


### PR DESCRIPTION
## Summary
- keep speaker colors stable by basing color order on persisted speaker ids
- persist speaker unsets by writing null speaker values back into the document model
- add player volume control plus a replay-slow action with an `Alt+R` shortcut
- add regression coverage for speaker id ordering and fix `Slider` typing so the new control type-checks cleanly

## Issues
Closes #478
Closes #503
Closes #505
Closes #521

## Validation
- `npm run check:tsc`
- `npm run check:eslint`
- `npm test -- --runInBand --watch=false`
- `npm run build:vite`

## Notes
- I also smoke-tested the preview build locally; the app shell loads, and the blank root page there is caused by missing backend endpoints (`/api/v1/users/me/` and `/api/v1/config/`) in preview mode.
