### PR TITLE
Fix local deployment

### DIFF
--- a/packaging/docker/Dockerfile
+++ b/packaging/docker/Dockerfile
@@ -49,7 +49,9 @@ COPY --from=frontend-builder /app/frontend/dist ./public
 COPY packaging/docker/run.sh /run.sh
 
 ENV STORAGE_PATH=/var/transcribee/storage
+ENV TOKEN_PATH=/var/transcribee/worker_token
 RUN mkdir -p "$STORAGE_PATH" && chown transcribee:transcribee "$STORAGE_PATH"
+RUN mkdir -p "$TOKEN_PATH" && chown transcribee:transcribee "$TOKEN_PATH"
 
 ENV PATH="/app/backend/.venv/bin:$PATH"
 


### PR DESCRIPTION
Local deployment failed because the worker token can not be written in run.sh:14 since the volume mounted in compose-local.yml is owned by root. Changing ownership of the volume directory here mounts the volume with correct permissions and allows creating the worker token file at runtime.