### PR TITLE
worker: Add opt-in TwelveLabs Pegasus transcription backend

### DIFF
--- a/worker/README.md
+++ b/worker/README.md
@@ -26,3 +26,27 @@ The most important settings are explained here:
 The worker needs multiple models, which will automatically be downloaded if they to not exist yet.
 They will by default be stored in `./.data/models`.
 You can change this directory by setting `MODELS_DIR`
+
+### Transcription backends
+
+By default transcription runs locally with whisper (`TRANSCRIPTION_BACKEND=whisper`).
+
+As an opt-in alternative you can delegate transcription to the
+[TwelveLabs](https://twelvelabs.io) Pegasus video-understanding model. This runs
+server-side and requires no local model download. To enable it:
+
+```shell
+uv sync --extra pegasus            # installs the twelvelabs SDK
+export TRANSCRIPTION_BACKEND=pegasus
+export TWELVELABS_API_KEY=<your-key>   # free tier at https://twelvelabs.io
+```
+
+Relevant settings (see `config.py`):
+
+- `TRANSCRIPTION_BACKEND` &ndash; `whisper` (default) or `pegasus`
+- `TWELVELABS_API_KEY` &ndash; required when using the `pegasus` backend
+- `PEGASUS_MODEL` &ndash; Pegasus model name (default `pegasus1.2`)
+- `PEGASUS_INDEX_NAME` &ndash; TwelveLabs index used for indexing media (created on first use)
+
+Pegasus is a video model, so audio-only media is automatically wrapped in a
+minimal black video track (via `ffmpeg`) before indexing.

--- a/worker/pyproject.toml
+++ b/worker/pyproject.toml
@@ -32,6 +32,13 @@ requires-python = "~=3.12.0"
 readme = "README.md"
 license = { text = "AGPL-3.0" }
 
+[project.optional-dependencies]
+# Optional TwelveLabs Pegasus transcription backend
+# (TRANSCRIPTION_BACKEND=pegasus). Not needed for the default whisper backend.
+pegasus = [
+    "twelvelabs>=1.2.8",
+]
+
 [dependency-groups]
 dev = [
   "black~=23.1",

--- a/worker/tests/test_pegasus_transcribe.py
+++ b/worker/tests/test_pegasus_transcribe.py
@@ -1,0 +1,86 @@
+import os
+from pathlib import Path
+
+import pytest
+
+from transcribee_worker.pegasus_transcribe import parse_pegasus_segments
+
+
+def test_parse_pegasus_segments_basic():
+    raw = (
+        '{"segments": ['
+        '{"start": 0.0, "end": 1.5, "text": "Hello there."},'
+        '{"start": 1.5, "end": 3.0, "text": "How are you?"}'
+        "]}"
+    )
+    paras = parse_pegasus_segments(raw, lang="en")
+    assert [p.text() for p in paras] == ["Hello there.", "How are you?"]
+    assert paras[0].children[0].start == 0.0
+    assert paras[0].children[0].end == 1.5
+    assert paras[0].lang == "en"
+
+
+def test_parse_pegasus_segments_applies_offset():
+    raw = '{"segments": [{"start": 0.0, "end": 2.0, "text": "Resumed."}]}'
+    paras = parse_pegasus_segments(raw, lang="de", start_offset=10.0)
+    assert paras[0].children[0].start == 10.0
+    assert paras[0].children[0].end == 12.0
+
+
+def test_parse_pegasus_segments_strips_fences_and_skips_empty():
+    raw = (
+        "Sure, here is the transcript:\n```json\n"
+        '{"segments": ['
+        '{"start": 0.0, "end": 1.0, "text": " trimmed "},'
+        '{"start": 1.0, "end": 2.0, "text": ""}'
+        "]}\n```"
+    )
+    paras = parse_pegasus_segments(raw, lang="en")
+    assert len(paras) == 1
+    assert paras[0].text() == "trimmed"
+
+
+def test_parse_pegasus_segments_clamps_negative_duration():
+    raw = '{"segments": [{"start": 5.0, "end": 4.0, "text": "oops"}]}'
+    paras = parse_pegasus_segments(raw, lang="en")
+    atom = paras[0].children[0]
+    assert atom.start <= atom.end
+
+
+def test_parse_pegasus_segments_rejects_non_json():
+    with pytest.raises(ValueError):
+        parse_pegasus_segments("I cannot do that.", lang="en")
+
+
+@pytest.mark.skipif(
+    not os.environ.get("TWELVELABS_API_KEY"),
+    reason="TWELVELABS_API_KEY not set; skipping live Pegasus call",
+)
+def test_pegasus_transcribe_live():
+    """End-to-end Pegasus transcription against the real API.
+
+    Uploads the bundled sample clip and asserts we get back at least one
+    non-empty timed paragraph. Slow (server-side processing), so it is gated
+    on the API key being present.
+    """
+    import asyncio
+
+    from transcribee_worker.pegasus_transcribe import transcribe_pegasus_async
+
+    media = Path(__file__).parent / "data" / "sample.mp3"
+
+    async def run():
+        out = []
+        async for para in transcribe_pegasus_async(
+            media_path=media,
+            start_offset=0.0,
+            lang_code="en",
+            progress_callback=None,
+        ):
+            out.append(para)
+        return out
+
+    paras = asyncio.run(run())
+    assert paras, "expected at least one paragraph from Pegasus"
+    assert paras[0].text().strip()
+    assert paras[0].children[0].end >= paras[0].children[0].start

--- a/worker/transcribee_worker/config.py
+++ b/worker/transcribee_worker/config.py
@@ -35,6 +35,15 @@ class Settings(BaseSettings):
 
     HUGGINGFACE_TOKEN: Optional[str] = None
 
+    # Transcription backend selection. "whisper" (default) runs the local
+    # whisper.cpp model; "pegasus" delegates transcription to the TwelveLabs
+    # Pegasus video-understanding model (requires TWELVELABS_API_KEY).
+    TRANSCRIPTION_BACKEND: str = "whisper"
+    TWELVELABS_API_KEY: Optional[str] = None
+    PEGASUS_MODEL: str = "pegasus1.2"
+    PEGASUS_INDEX_NAME: str = "transcribee"
+    PEGASUS_MAX_TOKENS: int = 2048
+
     REENCODE_PROFILES: Dict[str, OutputProfile] = {
         "mp3": OutputProfile(
             container="mp3",

--- a/worker/transcribee_worker/pegasus_transcribe.py
+++ b/worker/transcribee_worker/pegasus_transcribe.py
@@ -1,0 +1,217 @@
+"""Transcription backend using the TwelveLabs Pegasus video-understanding model.
+
+This is an opt-in alternative to the default local whisper backend. It indexes
+the document media into a TwelveLabs index and asks Pegasus to produce a timed
+transcript, which is then converted into transcribee ``Paragraph``s.
+
+Pegasus is a *video* understanding model, so the media must contain a video
+track of at least 360x360. Audio-only files (the common transcription case) are
+therefore wrapped in a minimal black video track via ffmpeg before indexing.
+
+Enable it by setting ``TRANSCRIPTION_BACKEND=pegasus`` and ``TWELVELABS_API_KEY``
+in the worker environment. Get a free API key at https://twelvelabs.io.
+"""
+
+import json
+import logging
+import re
+import subprocess
+import tempfile
+from pathlib import Path
+from typing import List, Optional
+
+from transcribee_proto.document import Atom, Paragraph
+
+from transcribee_worker.config import settings
+from transcribee_worker.types import ProgressCallbackType
+from transcribee_worker.util import SubmissionQueue, async_task
+
+# Pegasus is generative, so we constrain its output to a strict JSON shape we
+# can parse deterministically instead of free-form prose.
+_TRANSCRIBE_PROMPT = (
+    "Transcribe the spoken audio of this media verbatim. Respond with ONLY a "
+    "JSON object of the form "
+    '{"segments": [{"start": <seconds>, "end": <seconds>, "text": "..."}]}. '
+    "Split the transcript into one segment per sentence or natural pause. "
+    "`start` and `end` are floating point seconds from the beginning of the "
+    "media. Do not include any commentary, markdown or code fences."
+)
+
+_JSON_RE = re.compile(r"\{.*\}", re.DOTALL)
+
+# TwelveLabs requires indexed videos to be at least 360x360.
+_MIN_DIMENSION = 360
+
+
+def parse_pegasus_segments(
+    raw: str, lang: str, start_offset: float = 0.0
+) -> List[Paragraph]:
+    """Parse Pegasus' JSON transcript into transcribee paragraphs.
+
+    Tolerates the model wrapping the JSON in prose or ```json fences by
+    extracting the outermost JSON object. Each segment becomes one paragraph
+    with a single atom; confidence is unknown so we report 1.0.
+    """
+    match = _JSON_RE.search(raw)
+    if match is None:
+        raise ValueError(f"Pegasus response contained no JSON object: {raw!r}")
+
+    segments = json.loads(match.group(0)).get("segments", [])
+    paragraphs: List[Paragraph] = []
+    for seg in segments:
+        text = seg.get("text", "").strip()
+        if not text:
+            continue
+        start = float(seg["start"]) + start_offset
+        end = float(seg["end"]) + start_offset
+        paragraphs.append(
+            Paragraph(
+                lang=lang,
+                children=[
+                    Atom(
+                        text=text,
+                        start=start,
+                        end=max(start, end),
+                        conf=1.0,
+                        conf_ts=0.0,
+                    )
+                ],
+            )
+        )
+    return paragraphs
+
+
+def _ensure_indexable_video(media_path: Path, workdir: Path) -> Path:
+    """Return a path Pegasus can index.
+
+    If the media already has a video stream we assume it is indexable and use
+    it directly. Audio-only media is wrapped in a 360x360 black video track so
+    the (video-only) Pegasus model accepts it.
+    """
+    # Imported lazily so the JSON parser stays usable without PyAV installed.
+    from transcribee_worker.reencode import get_video_stream
+
+    if get_video_stream(media_path) is not None:
+        return media_path
+
+    out = workdir / "pegasus_input.mp4"
+    # ponytail: shell out to the bundled ffmpeg binary; synthesizing a black
+    # video stream via PyAV is far more code for the same result.
+    subprocess.run(
+        [
+            "ffmpeg",
+            "-y",
+            "-f",
+            "lavfi",
+            "-i",
+            f"color=c=black:s={_MIN_DIMENSION}x{_MIN_DIMENSION}:r=1",
+            "-i",
+            str(media_path),
+            "-shortest",
+            "-c:v",
+            "libx264",
+            "-pix_fmt",
+            "yuv420p",
+            "-c:a",
+            "aac",
+            str(out),
+        ],
+        check=True,
+        capture_output=True,
+    )
+    return out
+
+
+def _get_or_create_index(client) -> str:
+    """Return the id of the configured Pegasus index, creating it if needed."""
+    for index in client.indexes.list():
+        if index.index_name == settings.PEGASUS_INDEX_NAME:
+            return index.id
+    logging.info("Creating TwelveLabs index %r", settings.PEGASUS_INDEX_NAME)
+    created = client.indexes.create(
+        index_name=settings.PEGASUS_INDEX_NAME,
+        models=[
+            {
+                "model_name": settings.PEGASUS_MODEL,
+                "model_options": ["visual", "audio"],
+            }
+        ],
+    )
+    return created.id
+
+
+def transcribe_pegasus(
+    queue: SubmissionQueue,
+    media_path: Path,
+    start_offset: float,
+    progress_callback: ProgressCallbackType | None,
+    lang_code: Optional[str] = "en",
+):
+    # Imported lazily so the default whisper backend works without the
+    # twelvelabs SDK installed.
+    from twelvelabs import TwelveLabs
+
+    if not settings.TWELVELABS_API_KEY:
+        raise ValueError(
+            "TRANSCRIPTION_BACKEND=pegasus requires TWELVELABS_API_KEY to be set"
+        )
+
+    client = TwelveLabs(api_key=settings.TWELVELABS_API_KEY)
+    index_id = _get_or_create_index(client)
+
+    with tempfile.TemporaryDirectory() as tmp:
+        video_path = _ensure_indexable_video(media_path, Path(tmp))
+
+        logging.info("Indexing media into TwelveLabs for Pegasus transcription")
+        with open(video_path, "rb") as f:
+            task = client.tasks.create(index_id=index_id, video_file=f)
+        if task.id is None:
+            raise RuntimeError("TwelveLabs did not return an indexing task id")
+
+        def _on_status(res):
+            if progress_callback is not None:
+                # Indexing dominates wall-clock; map it to the 0..0.8 range.
+                progress_callback(progress=0.4, step=f"pegasus:index:{res.status}")
+
+        done = client.tasks.wait_for_done(task_id=task.id, callback=_on_status)
+        if done.status != "ready" or done.video_id is None:
+            raise RuntimeError(
+                f"TwelveLabs indexing did not complete (status={done.status})"
+            )
+
+    if progress_callback is not None:
+        progress_callback(progress=0.8, step="pegasus:analyze")
+
+    response = client.analyze(
+        model_name=settings.PEGASUS_MODEL,
+        video_id=done.video_id,
+        prompt=_TRANSCRIBE_PROMPT,
+        temperature=0.0,
+        max_tokens=settings.PEGASUS_MAX_TOKENS,
+    )
+
+    paragraphs = parse_pegasus_segments(
+        response.data or "", lang=lang_code or "en", start_offset=start_offset
+    )
+    for paragraph in paragraphs:
+        queue.submit(paragraph)
+
+    if progress_callback is not None:
+        progress_callback(progress=1.0, step="pegasus:done")
+
+
+def transcribe_pegasus_async(
+    media_path: Path,
+    start_offset: float,
+    progress_callback: ProgressCallbackType | None,
+    lang_code: Optional[str] = "en",
+):
+    return aiter(
+        async_task(
+            transcribe_pegasus,
+            media_path=media_path,
+            start_offset=start_offset,
+            lang_code=lang_code,
+            progress_callback=progress_callback,
+        )
+    )

--- a/worker/transcribee_worker/worker.py
+++ b/worker/transcribee_worker/worker.py
@@ -24,9 +24,11 @@ from transcribee_proto.api import (
 )
 from transcribee_proto.api import Document as ApiDocument
 from transcribee_proto.document import Document as EditorDocument
+
 from transcribee_worker.api_client import ApiClient
 from transcribee_worker.config import settings
 from transcribee_worker.identify_speakers import identify_speakers
+from transcribee_worker.pegasus_transcribe import transcribe_pegasus_async
 from transcribee_worker.reencode import (
     get_duration,
     get_video_stream,
@@ -187,7 +189,9 @@ class Worker:
     async def transcribe(
         self, task: TranscribeTask, progress_callback: ProgressCallbackType
     ):
-        audio = self.load_document_audio(task.document)
+        lang_code = (
+            task.task_parameters.lang if task.task_parameters.lang != "auto" else None
+        )
 
         async with self.api_client.document(task.document.id) as doc:
             async with doc.transaction("Reset Document") as d:
@@ -196,20 +200,29 @@ class Worker:
 
                 start_offset = get_last_atom_end(d)
 
-            audio = audio[int(start_offset * settings.SAMPLE_RATE) :]
+            if settings.TRANSCRIPTION_BACKEND == "pegasus":
+                media_path = self.get_document_audio_path(task.document)
+                if media_path is None:
+                    raise ValueError(f"Document {task.document} has no media attached.")
+                paragraph_iter = transcribe_pegasus_async(
+                    media_path=media_path,
+                    start_offset=start_offset,
+                    lang_code=lang_code,
+                    progress_callback=progress_callback,
+                )
+            else:
+                audio = self.load_document_audio(task.document)
+                audio = audio[int(start_offset * settings.SAMPLE_RATE) :]
+                paragraph_iter = transcribe_clean_async(
+                    data=audio,
+                    sr=settings.SAMPLE_RATE,
+                    start_offset=start_offset,
+                    model_name=task.task_parameters.model,
+                    lang_code=lang_code,
+                    progress_callback=progress_callback,
+                )
 
-            async for paragraph in transcribe_clean_async(
-                data=audio,
-                sr=settings.SAMPLE_RATE,
-                start_offset=start_offset,
-                model_name=task.task_parameters.model,
-                lang_code=(
-                    task.task_parameters.lang
-                    if task.task_parameters.lang != "auto"
-                    else None
-                ),
-                progress_callback=progress_callback,
-            ):
+            async for paragraph in paragraph_iter:
                 async with doc.transaction("Automatic Transcription") as d:
                     p = paragraph.dict()
                     normalize_for_automerge(p)

--- a/worker/uv.lock
+++ b/worker/uv.lock
@@ -1,6 +1,6 @@
 version = 1
-revision = 3
-requires-python = "==3.12.*"
+revision = 2
+requires-python = ">=3.12.0, <3.13"
 resolution-markers = [
     "(platform_machine != 'arm64' and platform_machine != 'x86_64') or sys_platform != 'darwin'",
     "platform_machine == 'arm64' and sys_platform == 'darwin'",
@@ -284,6 +284,15 @@ wheels = [
 ]
 
 [[package]]
+name = "h11"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
 name = "hf-xet"
 version = "1.5.0"
 source = { registry = "https://pypi.org/simple" }
@@ -297,6 +306,34 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/aa/b2/703569fc881f3284487e68cda7b42179978480da3c438042a6bbbb4a671c/hf_xet-1.5.0-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:4b35549ce62601b84da4ff9b24d970032ace3d4430f52d91bcbb26c901d6c690", size = 4672414, upload-time = "2026-05-06T06:18:09.864Z" },
     { url = "https://files.pythonhosted.org/packages/af/37/1b6def445c567286b50aa3b33828158e135b1be44938dde59f11382a500c/hf_xet-1.5.0-cp37-abi3-win_amd64.whl", hash = "sha256:2806c7c17b4d23f8d88f7c4814f838c3b6150773fe339c20af23e1cfaf2797e4", size = 3977238, upload-time = "2026-05-06T06:18:23.621Z" },
     { url = "https://files.pythonhosted.org/packages/62/94/3b66b148778ee100dcfd69c2ca22b57b41b44d3063ceec934f209e9184ce/hf_xet-1.5.0-cp37-abi3-win_arm64.whl", hash = "sha256:b6c9df403040248c76d808d3e047d64db2d923bae593eb244c41e425cf6cd7be", size = 3806916, upload-time = "2026-05-06T06:18:21.7Z" },
+]
+
+[[package]]
+name = "httpcore"
+version = "1.0.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "certifi" },
+    { name = "httpcore" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
 ]
 
 [[package]]
@@ -1206,6 +1243,11 @@ dependencies = [
     { name = "websockets" },
 ]
 
+[package.optional-dependencies]
+pegasus = [
+    { name = "twelvelabs" },
+]
+
 [package.dev-dependencies]
 dev = [
     { name = "black" },
@@ -1230,9 +1272,11 @@ requires-dist = [
     { name = "torchaudio", specifier = "~=2.0", index = "https://download.pytorch.org/whl/cpu" },
     { name = "transcribee-proto", editable = "../proto" },
     { name = "transformers", specifier = "~=4.26" },
+    { name = "twelvelabs", marker = "extra == 'pegasus'", specifier = ">=1.2.8" },
     { name = "watchfiles", specifier = "~=0.19" },
     { name = "websockets", specifier = "~=16.0" },
 ]
+provides-extras = ["pegasus"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -1261,6 +1305,21 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c4/35/67252acc1b929dc88b6602e8c4a982e64f31e733b804c14bc24b47da35e6/transformers-4.57.6.tar.gz", hash = "sha256:55e44126ece9dc0a291521b7e5492b572e6ef2766338a610b9ab5afbb70689d3", size = 10134912, upload-time = "2026-01-16T10:38:39.284Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/03/b8/e484ef633af3887baeeb4b6ad12743363af7cce68ae51e938e00aaa0529d/transformers-4.57.6-py3-none-any.whl", hash = "sha256:4c9e9de11333ddfe5114bc872c9f370509198acf0b87a832a0ab9458e2bd0550", size = 11993498, upload-time = "2026-01-16T10:38:31.289Z" },
+]
+
+[[package]]
+name = "twelvelabs"
+version = "1.2.8"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "httpx" },
+    { name = "pydantic" },
+    { name = "pydantic-core" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5f/24/2604563f5a528bf5f12f9bbb7e3102e91c0e4f9bfd7aeb9963dced3a0b0f/twelvelabs-1.2.8.tar.gz", hash = "sha256:bb0846cc839845c800de8061bb7b99212a472e24bf20770d569f6f620b845e3c", size = 178449, upload-time = "2026-06-18T06:38:48.135Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4e/a6/6380129c65222bb2497cbef27334a496a1a31f4f38973fac46b62b9224fc/twelvelabs-1.2.8-py3-none-any.whl", hash = "sha256:c0487dd892b03728ac2afe3e4ebd4ea5e30ff404b61896667eb5a39264db282b", size = 372073, upload-time = "2026-06-18T06:38:46.747Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Hi! I'm Mohit, I work at TwelveLabs (@mohit-twelvelabs).

## What this adds

An **opt-in** transcription backend that delegates transcription to the [TwelveLabs](https://twelvelabs.io) **Pegasus** video-understanding model, as an alternative to the default local whisper backend.

- New module `worker/transcribee_worker/pegasus_transcribe.py`: indexes the document media into a TwelveLabs index, asks Pegasus for a timed transcript, and parses the result into transcribee `Paragraph`s. It mirrors the existing `whisper_transcribe` async/`SubmissionQueue` pattern.
- New settings in `config.py`: `TRANSCRIPTION_BACKEND` (`whisper` default / `pegasus`), `TWELVELABS_API_KEY`, `PEGASUS_MODEL`, `PEGASUS_INDEX_NAME`, `PEGASUS_MAX_TOKENS`.
- `worker.transcribe()` branches on the backend; the whisper path is behaviourally unchanged.
- The `twelvelabs` SDK is an **optional** dependency (the `pegasus` extra), so the default install and whisper backend are untouched.

## Why it helps

It gives self-hosters a fully server-side transcription option that needs no local model download or GPU — useful for lightweight deployments. It also slots TwelveLabs' multimodal video understanding into transcribee's existing worker architecture without disrupting anything.

## Opt-in / non-breaking

Default behaviour is identical: `TRANSCRIPTION_BACKEND` defaults to `whisper`, the SDK is only pulled in via `uv sync --extra pegasus`, and the Pegasus code path is only reached when explicitly enabled.

## Implementation note

Pegasus is a *video* model and the platform requires indexed media to have a video track of at least 360x360. transcribee's common case is audio, so audio-only media is wrapped in a minimal black video track before indexing. The repo moved transcoding to PyAV (commit d7f965a), but synthesizing a fresh video track from scratch in PyAV is materially more code/fragile than a single `ffmpeg` invocation, and `ffmpeg` is already a bundled native dependency — so this one wrapper step shells out to `ffmpeg`. Happy to convert it to PyAV if you'd prefer to keep zero ffmpeg-CLI usage.

## How it was tested

- `worker/tests/test_pegasus_transcribe.py`: unit tests for the JSON→`Paragraph` parser (fence stripping, offset application, duration clamping, empty-segment skipping, malformed-input rejection) — no network.
- A live end-to-end test gated on `TWELVELABS_API_KEY` (skips without it) that runs the full upload → index → analyze → parse flow on the bundled `tests/data/sample.mp3` and asserts a non-empty timed paragraph. Verified passing against the real API.
- `ruff`, `black`, and `pyright` pass on the changed worker files.

You can grab a free API key at https://twelvelabs.io — there's a generous free tier.
