### PR TITLE
editor: remove start, end, conf and conf_ts props on paste

### DIFF
--- a/frontend/src/editor/automerge_websocket_editor.ts
+++ b/frontend/src/editor/automerge_websocket_editor.ts
@@ -9,6 +9,7 @@ import ReconnectingWebSocket from 'reconnecting-websocket';
 import { useDebugMode } from '../debugMode';
 import { Document, Paragraph } from './types';
 import { migrateDocument } from '../document';
+import { TextInsertFragmentOptions } from 'slate/dist/interfaces/transforms/text';
 
 enum MessageSyncType {
   Change = 1,
@@ -52,9 +53,22 @@ export function useAutomergeWebsocketEditor(
     let doc = Automerge.init();
 
     const createNewEditor = (doc: Automerge.Doc<Document>) => {
-      const baseEditor = createEditor();
-      const editorWithReact = withReact(baseEditor);
-      const editor = withHistory(withAutomergeDoc(editorWithReact, Automerge.init()));
+      const editor = withReact(withHistory(withAutomergeDoc(createEditor(), Automerge.init())));
+      const { insertFragment } = editor;
+      editor.insertFragment = (fragment, options?: TextInsertFragmentOptions | undefined) => {
+      const removeProp = (obj: any, toRemove: string[]) => {
+        for (const prop in obj) {
+          if (toRemove.includes(prop)) {
+            delete obj[prop]
+          } else if (typeof obj[prop] === 'object') {
+            removeProp(obj[prop], toRemove)
+          }
+        }
+        return obj
+      }
+      const cleanedFragment = removeProp(fragment, ["start", "end", "conf", "conf_ts"])
+      insertFragment(cleanedFragment, options)
+    }
       editor.addDocChangeListener(sendDocChange);
 
       const migratedDoc = migrateDocument(doc as Automerge.Doc<Document>);


### PR DESCRIPTION
This does not really work well at the moment, because we assume all nodes to have a `start` and `end`, so export is gated on it and the timeline sidebar displays "unknown" as timestamp.

To make this proper, we should probably insert the `start` and `end`, so that we fit inbetween our neigbours, but this is a bit tricky to do at this point....