### PR TITLE
pre-commit: factor out package-manager run checks

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,6 +9,9 @@ on:
 jobs:
   pre-commit:
     runs-on: ubuntu-latest
+    env:
+      SCCACHE_GHA_ENABLED: "true"
+      RUSTC_WRAPPER: "sccache"
     steps:
       - uses: actions/checkout@v6
 
@@ -22,6 +25,9 @@ jobs:
 
       - name: install ubuntu dependencies
         run: sudo apt-get update && sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf xdg-utils
+
+      - name: Run sccache-cache
+        uses: mozilla-actions/sccache-action@v0.0.10
 
       - name: run pre-commit
         run: pre-commit run --show-diff-on-failure --color=always --all-files

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -23,11 +23,5 @@ jobs:
       - name: install ubuntu dependencies
         run: sudo apt-get update && sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf xdg-utils
 
-      - name: install web dependencies
-        run: ./packaging/install_dependencies.sh
-
-      - name: install desktop dependencies
-        run: npm --prefix desktop/ ci
-
       - name: run pre-commit
         run: pre-commit run --show-diff-on-failure --color=always --all-files

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 .DS_Store
 .ruff_cache
 target
+
+# these are not uv.lock files but rather temporary files uv fails to clean up
+uv-*.lock

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,23 +26,18 @@ repos:
         language: system
         "types_or": [python, pyi]
 
-  # backend
+  # package manager managed projects
   - repo: local
     hooks:
-      - id: backend-pyright
-        name: "backend: pyright"
-        entry: poe -C backend/ pyright
+      - id: projects
+        name: "projects"
+        entry: packaging/pre-commit-projects.py
         language: system
-        files: backend/.*
-        pass_filenames: false
-  - repo: local
-    hooks:
-      - id: backend-test
-        name: "backend: test"
-        entry: poe -C backend/ test
-        language: system
-        files: backend/.*
-        pass_filenames: false
+        files: .*
+        pass_filenames: true
+        require_serial: true
+
+  # openapi
   - repo: local
     hooks:
       - id: backend-openapi
@@ -51,26 +46,6 @@ repos:
         language: system
         files: backend/.*
         pass_filenames: false
-
-  # worker
-  - repo: local
-    hooks:
-      - id: worker-pyright
-        name: "worker: pyright"
-        entry: poe -C worker/ pyright
-        language: system
-        files: worker/.*
-        pass_filenames: false
-  - repo: local
-    hooks:
-      - id: worker-tests
-        name: "worker: tests"
-        entry: poe -C worker/ test
-        language: system
-        files: worker/.*
-        pass_filenames: false
-
-  # frontend checks
   - repo: local # openapi-schema typescript from the openapi-schema of the backend
     hooks:
       - id: frontend-openapi-typescript
@@ -78,128 +53,4 @@ repos:
         entry: npm --prefix frontend/ run generate-openapi
         language: system
         files: backend/openapi-schema.yml
-        pass_filenames: false
-  - repo: local
-    hooks:
-      - id: frontend-eslint
-        name: "frontend: eslint"
-        entry: npm --prefix frontend/ run check:eslint
-        language: system
-        files: \.[jt]sx?$ # *.js, *.jsx, *.ts and *.tsx
-        pass_filenames: false
-  - repo: local
-    hooks:
-      - id: frontend-tsc
-        name: "frontend: tsc"
-        entry: npm --prefix frontend/ run check:tsc
-        language: system
-        files: frontend/.*
-        pass_filenames: false
-  - repo: local
-    hooks:
-      - id: frontend-format
-        name: "frontend: format"
-        entry: npm --prefix frontend/ run format
-        language: system
-        files: frontend/.*
-        pass_filenames: false
-  - repo: local
-    hooks:
-      - id: frontend-test
-        name: "frontend: test"
-        entry: npm --prefix frontend/ run test
-        language: system
-        files: frontend/.*
-        pass_filenames: false
-
-# ui-common
-  - repo: local
-    hooks:
-      - id: ui-common-eslint
-        name: "ui-common: eslint"
-        entry: npm --prefix ui-common/ run check:eslint
-        language: system
-        files: \.[jt]sx?$ # *.js, *.jsx, *.ts and *.tsx
-        pass_filenames: false
-  - repo: local
-    hooks:
-      - id: ui-common-tsc
-        name: "ui-common: tsc"
-        entry: npm --prefix ui-common/ run check:tsc
-        language: system
-        files: ui-common/.*
-        pass_filenames: false
-  - repo: local
-    hooks:
-      - id: ui-common-format
-        name: "ui-common: format"
-        entry: npm --prefix ui-common/ run format
-        language: system
-        files: ui-common/.*
-        pass_filenames: false
-  - repo: local
-    hooks:
-      - id: ui-common-test
-        name: "ui-common: test"
-        entry: npm --prefix ui-common/ run test
-        language: system
-        files: ui-common/.*
-        pass_filenames: false
-
-# desktop
-  - repo: local
-    hooks:
-      - id: desktop-eslint
-        name: "desktop: eslint"
-        entry: npm --prefix desktop/ run check:eslint
-        language: system
-        files: \.[jt]sx?$ # *.js, *.jsx, *.ts and *.tsx
-        pass_filenames: false
-  - repo: local
-    hooks:
-      - id: desktop-tsc
-        name: "desktop: tsc"
-        entry: npm --prefix desktop/ run check:tsc
-        language: system
-        files: desktop/.*
-        pass_filenames: false
-  - repo: local
-    hooks:
-      - id: desktop-format
-        name: "desktop: format"
-        entry: npm --prefix desktop/ run format
-        language: system
-        files: desktop/.*
-        pass_filenames: false
-  - repo: local
-    hooks:
-      - id: desktop-cargo-fmt
-        name: "desktop: cargo fmt"
-        entry: sh -c 'cd desktop/src-tauri/ && cargo fmt'
-        language: system
-        files: desktop/src-tauri/.*
-        pass_filenames: false
-  - repo: local
-    hooks:
-      - id: desktop-cargo-clippy
-        name: "desktop: cargo clippy"
-        entry: sh -c 'cd desktop/src-tauri/ && mkdir -p worker/ && cargo clippy --all-features --fix --allow-staged -- -D warnings'
-        language: system
-        files: desktop/src-tauri/.*
-        pass_filenames: false
-  - repo: local
-    hooks:
-      - id: desktop-worker-adapter-cargo-fmt
-        name: "desktop/worker-adapter: cargo fmt"
-        entry: sh -c 'cd desktop/src-tauri/ && cargo fmt'
-        language: system
-        files: desktop/worker-adapter/.*
-        pass_filenames: false
-  - repo: local
-    hooks:
-      - id: desktop-worker-adapter-cargo-clippy
-        name: "desktop/worker-adapter: cargo clippy"
-        entry: sh -c 'cd desktop/worker-adapter/ && cargo clippy --all-features --fix --allow-staged -- -D warnings'
-        language: system
-        files: desktop/src-tauri/.*
         pass_filenames: false

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -1849,6 +1849,9 @@ dependencies = [
 [package.metadata]
 requires-dist = [{ name = "pydantic", specifier = "~=2.2" }]
 
+[package.metadata.requires-dev]
+dev = [{ name = "pyright", specifier = "~=1.1" }]
+
 [[package]]
 name = "types-python-dateutil"
 version = "2.9.0.20241206"

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -11,7 +11,8 @@
     "check": "npm-run-all --continue-on-error check:*",
     "check:tsc": "tsc --noEmit --incremental",
     "check:eslint": "eslint --max-warnings 0 --ext .ts,.tsx .",
-    "check:format": "prettier --check 'src/**/*.(ts|tsx)'"
+    "check:format": "prettier --check 'src/**/*.(ts|tsx)'",
+    "test": "echo 'nothing to do yet'"
   },
   "dependencies": {
     "@automerge/automerge": "~3.3.1",

--- a/desktop/src-tauri/build.rs
+++ b/desktop/src-tauri/build.rs
@@ -1,3 +1,22 @@
+use std::{
+    fs::{create_dir_all, remove_dir_all},
+    process::Command,
+};
+
+use tauri_build::is_dev;
+
 fn main() {
+    // in dev mode we simply start the worker from ../../worker with uv while in production
+    // we use the bundled worker. We still need to create an empty worker/ dir in dev to make
+    // the tauri build process happy.
+    if is_dev() {
+        let _ = remove_dir_all("worker");
+        create_dir_all("worker").expect("could not create worker/ dir");
+    } else {
+        Command::new("python")
+            .args(["src-tauri/prepare_worker.py"])
+            .output()
+            .expect("failed to build worker bundle");
+    }
     tauri_build::build()
 }

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -82,11 +82,11 @@ pub fn run() {
         })
         .setup(|app| {
             let worker_adapter = app.state::<WorkerAdapter>();
-            tokio::runtime::Handle::current().block_on(worker_adapter.add_change_listener(
-                |doc, change| {
+            tokio::runtime::Runtime::new()
+                .unwrap()
+                .block_on(worker_adapter.add_change_listener(|doc, change| {
                     println!("Change for {:?}: {:?}", doc, change);
-                },
-            ));
+                }));
             Ok(())
         })
         .run(tauri::generate_context!())

--- a/desktop/src-tauri/src/worker_plugin.rs
+++ b/desktop/src-tauri/src/worker_plugin.rs
@@ -1,6 +1,8 @@
 use log::{error, info, log, Level};
 use rand::{distr::Alphanumeric, RngExt};
 use std::{net::SocketAddr, time::Duration};
+#[cfg(debug_assertions)]
+use tauri::is_dev;
 use tauri::{
     path::BaseDirectory,
     plugin::{Builder, TauriPlugin},
@@ -34,17 +36,30 @@ fn setup_worker<R: Runtime>(
 
         loop {
             info!(target: "worker", "starting worker");
-            let (mut events, _) = shell
-                .command(resource_path.clone())
-                .env("WORKER_TYPE", "desktop")
-                .args([
+
+            // in dev mode we simply start the worker from ../../worker with uv while in production
+            // we use the bundled worker
+            let builder = if is_dev() {
+                shell
+                    .command("uv")
+                    .args([
+                        "run",
+                        "transcribee-worker",
+                        "--coordinator",
+                        &format!("http://{}:{}", local_addr.ip(), local_addr.port()),
+                        "--token",
+                        &token,
+                    ])
+                    .current_dir("../../worker")
+            } else {
+                shell.command(resource_path.clone()).args([
                     "--coordinator",
                     &format!("http://{}:{}", local_addr.ip(), local_addr.port()),
                     "--token",
                     &token,
                 ])
-                .spawn()
-                .unwrap();
+            };
+            let (mut events, _) = builder.env("WORKER_TYPE", "desktop").spawn().unwrap();
 
             let mut stderr = Vec::new();
             let mut stdout = Vec::new();

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -4,9 +4,9 @@
   "version": "0.1.0",
   "identifier": "org.bugbakery.transcribee-desktop",
   "build": {
-    "beforeDevCommand": "python src-tauri/prepare_worker.py && npm run dev",
+    "beforeDevCommand": "npm run dev",
     "devUrl": "http://localhost:1420",
-    "beforeBuildCommand": "python src-tauri/prepare_worker.py && npm run build",
+    "beforeBuildCommand": "npm run build",
     "frontendDist": "../dist"
   },
   "app": {

--- a/flake.lock
+++ b/flake.lock
@@ -20,72 +20,23 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1778792364,
-        "narHash": "sha256-R04tT1funsWlsVALA45h9q6rAylulA00EEn4Swt0+/o=",
+        "lastModified": 1784802721,
+        "narHash": "sha256-sF/Bctmj/KabQYehqPvvosN1Y5Wg2f+OIGLPS7fp2s0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "12d453b5581cdde2f8edb0147717e3f0112d15b9",
+        "rev": "20a74362aad184e5955ddb72caa068f6abfac306",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "pyproject-build-systems": {
-      "inputs": {
-        "nixpkgs": [
-          "nixpkgs"
-        ],
-        "pyproject-nix": [
-          "pyproject-nix"
-        ],
-        "uv2nix": [
-          "uv2nix"
-        ]
-      },
-      "locked": {
-        "lastModified": 1776659114,
-        "narHash": "sha256-qapCOQmR++yZSY43dzrp3wCrkOTLpod+ONtJWBk6iKU=",
-        "owner": "pyproject-nix",
-        "repo": "build-system-pkgs",
-        "rev": "ffaa2161dd5d63e0e94591f86b54fc239660fb2e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "pyproject-nix",
-        "repo": "build-system-pkgs",
-        "type": "github"
-      }
-    },
-    "pyproject-nix": {
-      "inputs": {
-        "nixpkgs": [
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1776715674,
-        "narHash": "sha256-Gs1VnEkCkkRZxJQAC/Dhz0Jbfi22mFXChbtNg9w/Ybg=",
-        "owner": "pyproject-nix",
-        "repo": "pyproject.nix",
-        "rev": "69f57f27e52a87c54e28138a75ec741cd46663c9",
-        "type": "github"
-      },
-      "original": {
-        "owner": "pyproject-nix",
-        "repo": "pyproject.nix",
         "type": "github"
       }
     },
     "root": {
       "inputs": {
         "flake-utils": "flake-utils",
-        "nixpkgs": "nixpkgs",
-        "pyproject-build-systems": "pyproject-build-systems",
-        "pyproject-nix": "pyproject-nix",
-        "uv2nix": "uv2nix"
+        "nixpkgs": "nixpkgs"
       }
     },
     "systems": {
@@ -100,29 +51,6 @@
       "original": {
         "owner": "nix-systems",
         "repo": "default",
-        "type": "github"
-      }
-    },
-    "uv2nix": {
-      "inputs": {
-        "nixpkgs": [
-          "nixpkgs"
-        ],
-        "pyproject-nix": [
-          "pyproject-nix"
-        ]
-      },
-      "locked": {
-        "lastModified": 1778664018,
-        "narHash": "sha256-ogNyNANNLo0SMFevIeUpbTMOL9uUDu/hXvp7JlOYbwQ=",
-        "owner": "pyproject-nix",
-        "repo": "uv2nix",
-        "rev": "b48abe99ef639cd100c224898529370e5d935294",
-        "type": "github"
-      },
-      "original": {
-        "owner": "pyproject-nix",
-        "repo": "uv2nix",
         "type": "github"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -3,34 +3,12 @@
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs";
-
-    pyproject-nix = {
-      url = "github:pyproject-nix/pyproject.nix";
-      inputs.nixpkgs.follows = "nixpkgs";
-    };
-
-    uv2nix = {
-      url = "github:pyproject-nix/uv2nix";
-      inputs.pyproject-nix.follows = "pyproject-nix";
-      inputs.nixpkgs.follows = "nixpkgs";
-    };
-
-    pyproject-build-systems = {
-      url = "github:pyproject-nix/build-system-pkgs";
-      inputs.pyproject-nix.follows = "pyproject-nix";
-      inputs.uv2nix.follows = "uv2nix";
-      inputs.nixpkgs.follows = "nixpkgs";
-    };
-
     flake-utils.url = "github:numtide/flake-utils";
   };
 
   outputs =
     {
       nixpkgs,
-      uv2nix,
-      pyproject-nix,
-      pyproject-build-systems,
       flake-utils,
       self,
       ...

--- a/packaging/pre-commit-projects.py
+++ b/packaging/pre-commit-projects.py
@@ -16,7 +16,7 @@ PROJECT_FILE_TYPES = {
     "package.json": {
         "install": "npm install",
         "checks": {
-            "test": "npm run test run",
+            "test": "npm run test run -- --test-timeout=20000",
             "tsc": "npm run check:tsc",
             "eslint": "npm run check:eslint",
             "format": "npm run format",

--- a/packaging/pre-commit-projects.py
+++ b/packaging/pre-commit-projects.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+# this script runs pre-commit checks for projects that are managed via package managers.
+# It currently supports uv, npm and cargo. For each respective package manager it searches a project
+# files (pyproject.toml, package.json or Cargo.toml) and runs the commands that we have as a
+# conventon for that language to check and lint the project. It automatically discovers all
+# projects in the transcribee monorepo.
+
+from pathlib import Path
+from subprocess import PIPE, STDOUT, Popen, check_output, run
+from sys import argv
+from textwrap import indent
+from threading import Thread
+from time import sleep
+
+PROJECT_FILE_TYPES = {
+    "package.json": {
+        "install": "npm install",
+        "checks": {
+            "test": "npm run test run",
+            "tsc": "npm run check:tsc",
+            "eslint": "npm run check:eslint",
+            "format": "npm run format",
+        },
+    },
+    "pyproject.toml": {
+        "install": "uv sync --dev",
+        "checks": {
+            "test": "poe -q test",
+            "pyright": "poe -q pyright",
+        },
+    },
+    "Cargo.toml": {
+        "install": "cargo fetch",
+        "checks": {
+            "fmt": "cargo fmt",
+            "clippy": (
+                "cargo clippy --all-features --fix --allow-dirty --allow-staged -- -D warnings"
+            ),
+            "test": "cargo test --all-features",
+        },
+    },
+}
+
+if __name__ == "__main__":
+    root = Path(__file__).parent.parent
+    repo_files = (
+        check_output(
+            "git ls-files --cached --others --exclude-standard",
+            shell=True,
+            cwd=str(root),
+        )
+        .decode()
+        .splitlines()
+    )
+    project_files = [
+        f
+        for f in repo_files
+        if any(f.endswith(f"/{end}") for end in PROJECT_FILE_TYPES.keys())
+    ]
+
+    if len(argv) > 1:
+        dirty_files = argv[1:]
+        project_files = [
+            p
+            for p in project_files
+            if any(d.startswith(str(Path(p).parent)) for d in dirty_files)
+        ]
+
+    print("-> installing dependencies...")
+    handles: dict[str, Popen] = {}
+    for proj in project_files:
+        proj = Path(proj)
+        project_dir = (root / proj).parent
+        cmd = PROJECT_FILE_TYPES[proj.name]["install"]
+        handle = Popen(
+            cmd, cwd=str(project_dir), shell=True, stderr=STDOUT, stdout=PIPE
+        )
+        handles[str(proj.parent)] = handle
+    errors = []
+    for name, handle in handles.items():
+        returncode = handle.wait()
+        if returncode != 0:
+            print(f"❌ {name}:install")
+            print(handle.stdout)
+            errors.append(name)
+
+    if len(errors) != 0:
+        print("installing dependencies has failed")
+        exit(1)
+
+    print("-> running hooks...")
+    processes = {}
+
+    def spawn(key, cmd, project_dir):
+        completed = run(
+            f"DYLD_LIBRARY_PATH=$TRANSCRIBEE_DYLD_LIBRARY_PATH {cmd}",
+            cwd=str(project_dir),
+            shell=True,
+            stderr=STDOUT,
+            stdout=PIPE,
+            text=True,
+        )
+        if completed.returncode == 0:
+            print(f"✅ {key}")
+        else:
+            print(f"❌ {key}:")
+            print(indent(completed.stdout, "   "))
+            global errors
+            errors.append(key)
+        processes.pop(key)
+
+    for proj in project_files:
+        proj = Path(proj)
+        project_dir = (root / proj).parent
+        for name, cmd in PROJECT_FILE_TYPES[proj.name]["checks"].items():
+            key = f"{proj.parent}:{name}"
+            thread = Thread(target=spawn, args=(key, cmd, project_dir))
+            thread.start()
+            processes[key] = thread
+
+    while len(processes) > 0:
+        sleep(0.1)
+
+    if len(errors) > 0:
+        print(f"\n{len(errors)} checks have failed: {', '.join(errors)}")
+        exit(1)
+    else:
+        print("all good :)")

--- a/proto/pyproject.toml
+++ b/proto/pyproject.toml
@@ -12,12 +12,23 @@ authors = [
 dependencies = [
     "pydantic~=2.2",
 ]
+
 requires-python = "~=3.12.0"
 readme = "README.md"
 license = {text = "AGPL-3.0"}
 
+[dependency-groups]
+dev = [
+  "pyright~=1.1",
+]
+
 [tool.setuptools]
 packages = ["transcribee_proto"]
+
+[tool.poe.tasks]
+test = "echo 'nothing to do'"
+pyright = "pyright transcribee_proto/"
+
 
 [tool.uv]
 cache-keys = [{ file = "pyproject.toml" }, { file = "**/*.py" }] # add python files to cache key, otherwise uv will cache too agressively

--- a/proto/transcribee_proto/api.py
+++ b/proto/transcribee_proto/api.py
@@ -62,7 +62,9 @@ class SpeakerIdentificationTaskParameters(BaseModel):
 
 
 class SpeakerIdentificationTask(TaskBase):
-    task_type: Literal[TaskType.IDENTIFY_SPEAKERS] = TaskType.IDENTIFY_SPEAKERS
+    task_type: Literal[  # pyright: ignore reportIncompatibleVariableOverride
+        TaskType.IDENTIFY_SPEAKERS
+    ] = TaskType.IDENTIFY_SPEAKERS
     task_parameters: SpeakerIdentificationTaskParameters
 
 
@@ -84,17 +86,23 @@ class ExportTaskParameters(BaseModel):
 
 
 class TranscribeTask(TaskBase):
-    task_type: Literal[TaskType.TRANSCRIBE] = TaskType.TRANSCRIBE
+    task_type: Literal[  # pyright: ignore reportIncompatibleVariableOverride
+        TaskType.TRANSCRIBE
+    ] = TaskType.TRANSCRIBE
     task_parameters: TranscribeTaskParameters
 
 
 class ReencodeTask(TaskBase):
-    task_type: Literal[TaskType.REENCODE] = TaskType.REENCODE
+    task_type: Literal[  # pyright: ignore reportIncompatibleVariableOverride
+        TaskType.REENCODE
+    ] = TaskType.REENCODE
     task_parameters: Dict[str, Any]
 
 
 class ExportTask(TaskBase):
-    task_type: Literal[TaskType.EXPORT] = TaskType.EXPORT
+    task_type: Literal[  # pyright: ignore reportIncompatibleVariableOverride
+        TaskType.EXPORT
+    ] = TaskType.EXPORT
     task_parameters: ExportTaskParameters
 
 

--- a/proto/uv.lock
+++ b/proto/uv.lock
@@ -12,6 +12,15 @@ wheels = [
 ]
 
 [[package]]
+name = "nodeenv"
+version = "1.10.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/24/bf/d1bda4f6168e0b2e9e5958945e01910052158313224ada5ce1fb2e1113b8/nodeenv-1.10.0.tar.gz", hash = "sha256:996c191ad80897d076bdfba80a41994c2b47c68e224c542b48feba42ba00f8bb", size = 55611, upload-time = "2025-12-20T14:08:54.006Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/b2/d0896bdcdc8d28a7fc5717c305f1a861c26e18c05047949fb371034d98bd/nodeenv-1.10.0-py2.py3-none-any.whl", hash = "sha256:5bb13e3eed2923615535339b3c620e76779af4cb4c6a90deccc9e36b274d3827", size = 23438, upload-time = "2025-12-20T14:08:52.782Z" },
+]
+
+[[package]]
 name = "pydantic"
 version = "2.10.5"
 source = { registry = "https://pypi.org/simple" }
@@ -51,6 +60,19 @@ wheels = [
 ]
 
 [[package]]
+name = "pyright"
+version = "1.1.411"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nodeenv" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7e/ab/265f7dc69d28113ebba19092e57b075f41543b2ed048429c5f56e2b88eac/pyright-1.1.411.tar.gz", hash = "sha256:d885a0551f2e763b089a02702174e7f4ba77548cddabc972ab86d1f7f1b0f998", size = 4112861, upload-time = "2026-06-25T02:14:06.37Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0a/49/385be530a6a5b78d1cbcd5c2e38debc8959a2fc6bdb716f4e581002979fc/pyright-1.1.411-py3-none-any.whl", hash = "sha256:dc7c72a8e2700c55baa127554040e067041ea53ccfd50bf96308cc4291c7d5d9", size = 6181526, upload-time = "2026-06-25T02:14:04.691Z" },
+]
+
+[[package]]
 name = "transcribee-proto"
 version = "0.1.0"
 source = { editable = "." }
@@ -58,8 +80,16 @@ dependencies = [
     { name = "pydantic" },
 ]
 
+[package.dev-dependencies]
+dev = [
+    { name = "pyright" },
+]
+
 [package.metadata]
 requires-dist = [{ name = "pydantic", specifier = "~=2.2" }]
+
+[package.metadata.requires-dev]
+dev = [{ name = "pyright", specifier = "~=1.1" }]
 
 [[package]]
 name = "typing-extensions"

--- a/ui-common/package.json
+++ b/ui-common/package.json
@@ -20,7 +20,7 @@
     "check": "npm-run-all --continue-on-error check:*",
     "check:tsc": "tsc --noEmit --incremental",
     "check:eslint": "eslint --max-warnings 0 --ext .ts,.tsx .",
-    "check:format": "prettier --check 'src/**/*.(ts|tsx)'",
+    "check:format": "prettier --check '**/*.(ts|tsx)'",
     "test": "vitest"
   },
   "dependencies": {

--- a/worker/uv.lock
+++ b/worker/uv.lock
@@ -1179,6 +1179,9 @@ dependencies = [
 [package.metadata]
 requires-dist = [{ name = "pydantic", specifier = "~=2.2" }]
 
+[package.metadata.requires-dev]
+dev = [{ name = "pyright", specifier = "~=1.1" }]
+
 [[package]]
 name = "transcribee-worker"
 version = "0.1.0"


### PR DESCRIPTION
common checks that are run through the package manager are now invoked through a bespoke python script. this allows us to execute them in paralell (making it faster), installing the dependencies before running the checks (making it more correct) and allowing us to automatically discover projects (preventing stupid mistakes we had in the past)