### PR TITLE
desktop: sign macOS app with bollox cert

### DIFF
--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -36,6 +36,9 @@
       "appimage": {
         "bundleMediaFramework": true
       }
+    },
+    "macOS": {
+      "signingIdentity": "-"
     }
   }
 }


### PR DESCRIPTION
because on arm mac all apps need to be signed